### PR TITLE
Use __str__ to calculate the BaseInstance display name for team view

### DIFF
--- a/simpl/models.py
+++ b/simpl/models.py
@@ -393,6 +393,9 @@ class BaseInstance(DataMixin, models.Model):
         abstract = True
         ordering = ("-date_created",)
 
+    def __str__(self):
+        return self.name
+
     def save(self, *args, **kwargs):
         if not self.name:
             if self.run and self.run.game:

--- a/simpl/schema/external/types.py
+++ b/simpl/schema/external/types.py
@@ -44,7 +44,7 @@ class SimplInstance(DjangoObjectType):
     """
     A Simpl game instance
     """
-
+    name = graphene.String(calculated=graphene.Boolean())
     status = graphene.Field(InstanceStatus)
     players = graphene.List(
         graphene.ID, description="List of Auth0 IDs for players of this instance"
@@ -54,7 +54,11 @@ class SimplInstance(DjangoObjectType):
     class Meta:
         model = Instance
         skip_registry = True
-        fields = ["name", "date_end"]
+        fields = ["date_end"]
+
+    @staticmethod
+    def resolve_name(obj, info, calculated=True):
+        return str(obj) if calculated else obj.name
 
     @staticmethod
     def resolve_status(obj, info):
@@ -160,7 +164,7 @@ class SimplUserInstance(graphene.ObjectType):
     """
 
     # Actually based on a Character model instance.
-    name = graphene.String()
+    name = graphene.String(calculated=graphene.Boolean())
     status = graphene.Field(InstanceStatus)
     date_end = graphene.DateTime()
     url = graphene.Field(graphene.String, deprecation_reason="Use SimplUserRun.url")
@@ -169,8 +173,8 @@ class SimplUserInstance(graphene.ObjectType):
     player_finished = graphene.DateTime()
 
     @staticmethod
-    def resolve_name(obj, info):
-        return obj.instance.name
+    def resolve_name(obj, info, calculated=True):
+        return str(obj.instance) if calculated else obj.instance.name
 
     @staticmethod
     def resolve_status(obj, info):

--- a/simpl/views.py
+++ b/simpl/views.py
@@ -157,8 +157,9 @@ class PlayersView(SimplMixin, DetailView):
         if self.run.multiplayer:
             teams = {}
             for player in active_players:
-                teams.setdefault(player.character.instance.name, [])
-                teams[player.character.instance.name].append(player)
+                team_name = str(player.character.instance)
+                teams.setdefault(team_name, [])
+                teams[team_name].append(player)
             context["teams"] = teams
         context["players"] = active_players
         context["players_count"] = active_count


### PR DESCRIPTION
Previously, the players view used `BaseInstance.name` to diaplay the team name.

Changing this enables BaseInstance subclasses to customise how names are displayed more easily by overriding `__str__`, and have that change be mirrored in the Eduled interface. It's necessary for ARC, which wants to display both the new and original instance name if they differ.

This PR adds a `__str__` method to `BaseInstance` which returns `self.name` as a default, so no changes should be necessary for other users of this package.